### PR TITLE
Update usage example in README to better match generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Call webpack's [`require.context`](https://webpack.js.org/api/module-methods/#re
 import { Application } from "@hotwired/stimulus"
 import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers"
 
-window.Stimulus = Application.start()
+const application = Application.start()
 const context = require.context("./controllers", true, /\.js$/)
-Stimulus.load(definitionsFromContext(context))
+application.load(definitionsFromContext(context))
+window.Stimulus = application
 ```
 
 ## Getting Help & Contributing Back


### PR DESCRIPTION
This updates the code sample in the README to better match the generated code from `bin/rails stimulus:install`, which generates the following:

```js
import { Application } from '@hotwired/stimulus'

const application = Application.start()

// Configure Stimulus development experience
application.warnings = true
application.debug = false
window.Stimulus = application

export { application }
```