### PR TITLE
Add slash to logicalName regex

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export function definitionForModuleAndIdentifier(module: ECMAScriptModule, ident
 }
 
 export function identifierForContextKey(key: string): string | undefined {
-  const logicalName = (key.match(/^(?:\.\/)?(.+)(?:[_-]controller\..+?)$/) || [])[1]
+  const logicalName = (key.match(/^(?:\.\/)?(.+)(?:[/_-]controller\..+?)$/) || [])[1]
   if (logicalName) {
     return logicalName.replace(/_/g, "-").replace(/\//g, "--")
   }


### PR DESCRIPTION
Add a slash for a nicer workflow with namespaces controllers.
With the slash for example `base/autocomplete/controller.js` will translated to `base--autocomplete`.
Without the slash we need an additional name for the controller, like `base/autocomplete/component_controller.js`. Which will translated to `base--autocomplete--component`